### PR TITLE
Rename namespace to admengine

### DIFF
--- a/app/main.cpp
+++ b/app/main.cpp
@@ -5,7 +5,7 @@
 #include "adm_engine/renderer.hpp"
 #include "adm_engine/parser.hpp"
 
-using namespace admrenderer;
+using namespace admengine;
 
 int dumpBw64AdmFile(const char* path) {
   auto bw64File = bw64::readFile(path);

--- a/src/adm_engine/adm_helper.cpp
+++ b/src/adm_engine/adm_helper.cpp
@@ -1,7 +1,7 @@
 
 #include "adm_helper.hpp"
 
-namespace admrenderer {
+namespace admengine {
 
 std::shared_ptr<adm::AudioObject> createAdmAudioObject(const adm::AudioObjectName& audioObjectName, const ear::Layout& outputLayout) {
   auto mixObject = adm::AudioObject::create(audioObjectName);

--- a/src/adm_engine/adm_helper.hpp
+++ b/src/adm_engine/adm_helper.hpp
@@ -7,7 +7,7 @@
 #include <bw64/bw64.hpp>
 #include <ear/ear.hpp>
 
-namespace admrenderer {
+namespace admengine {
 
 std::shared_ptr<adm::AudioObject> createAdmAudioObject(const adm::AudioObjectName& audioObjectName, const ear::Layout& outputLayout);
 

--- a/src/adm_engine/audio_object_renderer.cpp
+++ b/src/adm_engine/audio_object_renderer.cpp
@@ -5,7 +5,7 @@
 
 #include <adm/common_definitions.hpp>
 
-namespace admrenderer {
+namespace admengine {
 
 AudioObjectRenderer::AudioObjectRenderer(const ear::Layout& outputLayout,
                       const std::shared_ptr<adm::AudioObject>& audioObject,

--- a/src/adm_engine/audio_object_renderer.hpp
+++ b/src/adm_engine/audio_object_renderer.hpp
@@ -4,7 +4,7 @@
 #include <adm/adm.hpp>
 #include <bw64/bw64.hpp>
 
-namespace admrenderer {
+namespace admengine {
 
 class AudioObjectRenderer {
 

--- a/src/adm_engine/parser.cpp
+++ b/src/adm_engine/parser.cpp
@@ -4,7 +4,7 @@
 
 #include "parser.hpp"
 
-namespace admrenderer {
+namespace admengine {
 
   std::shared_ptr<adm::Document> getAdmDocument(const std::shared_ptr<bw64::AxmlChunk>& axmlChunk) {
     std::stringstream axmlStringstream;

--- a/src/adm_engine/parser.hpp
+++ b/src/adm_engine/parser.hpp
@@ -5,7 +5,7 @@
 
 #include <bw64/bw64.hpp>
 
-namespace admrenderer {
+namespace admengine {
 
   std::shared_ptr<adm::Document> getAdmDocument(const std::shared_ptr<bw64::AxmlChunk>& axmlChunk);
   std::shared_ptr<bw64::AxmlChunk> parseAdmXmlChunk(const std::unique_ptr<bw64::Bw64Reader>& bw64File);

--- a/src/adm_engine/renderer.cpp
+++ b/src/adm_engine/renderer.cpp
@@ -3,7 +3,7 @@
 #include "renderer.hpp"
 #include "parser.hpp"
 
-namespace admrenderer {
+namespace admengine {
 
 Renderer::Renderer(const std::unique_ptr<bw64::Bw64Reader>& inputFile,
            const std::string& outputLayout,

--- a/src/adm_engine/renderer.hpp
+++ b/src/adm_engine/renderer.hpp
@@ -12,7 +12,7 @@
 #define PATH_SEPARATOR "/"
 #endif
 
-namespace admrenderer {
+namespace admengine {
 
 const unsigned int BLOCK_SIZE = 4096; // in frames
 


### PR DESCRIPTION
After https://github.com/media-cloud-ai/adm_engine/issues/8